### PR TITLE
"SimpleCircuit" mode, Make.config.template

### DIFF
--- a/STM32F103/Make.config.template
+++ b/STM32F103/Make.config.template
@@ -1,0 +1,23 @@
+#
+# User defined Makefile options for the IRMP_STM32 firmware
+#
+# Copy this file to 'Make.config' and change the parameters as necessary.
+#
+
+### Specify the target board here.
+### Default is to build a firmware for the STM32F103 development board.
+### Red --> Build for the "Red" ST-Link board or one of the ST-Link "USB-sticks"
+### Blue --> Build for the "Blue" ST-Link board
+#Platform=Red
+#Platform=Blue
+
+### Enable this if your firmware is meant to run on a board with the Maple
+### bootloader installed.
+#Bootloader=1
+
+### If you enable the following option, your firmware will be able to drive the
+### "active" pin of the mainboard power button directly. It is recommended
+### to add a 220 ohms resistor between board pin and the mainboard connector.
+### Default is to build a firmware which is meant to drive the power button via
+### an opto-coupler added between STM32 board and mainboard.
+#SimpleCircuit=1

--- a/STM32F103/Makefile
+++ b/STM32F103/Makefile
@@ -60,8 +60,10 @@ prepare:
 flash: $(TARGET).bin
 	stm32flash -v -w $(TARGET).bin /dev/ttyUSB0
 
-clean:
+clean-objects:
 	rm -f $(OBJS) $(TARGET).{bin,elf,map}
+
+clean: clean-objects
 	rm -rf cmsis cmsis_boot irmp stm_lib usb_hid ext_src/prepared
 
 distclean: clean

--- a/STM32F103/Makefile
+++ b/STM32F103/Makefile
@@ -1,3 +1,5 @@
+-include Make.config
+
 TARGET ?= IR
 PLATFORM ?= STM32F103C8
 #STM32F103C8

--- a/STM32F103/Makefile
+++ b/STM32F103/Makefile
@@ -40,6 +40,10 @@ else
 LDFLAGS = -nostartfiles -Wl,-Map=$(TARGET).map,--gc-sections,--entry=main,-Tscripts/arm-gcc-link.ld $(ARCH) $(COMMON)
 endif
 
+ifdef SimpleCircuit
+DEFINES += -DSimpleCircuit
+endif
+
 ifeq ($(Platform), Blue)
 DEFINES += -DBlueLink
 endif

--- a/STM32F103/Makefile
+++ b/STM32F103/Makefile
@@ -32,12 +32,21 @@ OBJS = src/irmpmain.o src/st_link_leds.o src/usb_hid.o src/main.o\
        usb_hid/src/usb_sil.o
 
 CFLAGS = -Wall -ffunction-sections -fno-builtin $(ARCH) $(COMMON) $(INCLUDES) $(DEFINES)
+
 ifdef Bootloader
 DEFINES += -DBootloader
 LDFLAGS = -nostartfiles -Wl,-Map=$(TARGET).map,--gc-sections,--entry=main,-Tscripts/arm-gcc-link-bootloader.ld $(ARCH) $(COMMONOC)
 else
 LDFLAGS = -nostartfiles -Wl,-Map=$(TARGET).map,--gc-sections,--entry=main,-Tscripts/arm-gcc-link.ld $(ARCH) $(COMMON)
 endif
+
+ifeq ($(Platform), Blue)
+DEFINES += -DBlueLink
+endif
+ifeq ($(Platform), Red)
+DEFINES += -DRedLink
+endif
+
 $(TARGET).bin: $(TARGET).elf
 	$(OBJCP) -O binary $< $@
 

--- a/STM32F103/src/main.c
+++ b/STM32F103/src/main.c
@@ -179,16 +179,24 @@ void LED_Switch_init(void)
 	/* disable SWD, so pins are available */
 	GPIO_PinRemapConfig(GPIO_Remap_SWJ_Disable, ENABLE);
 	/* start with wakeup switch off */
+#ifdef SimpleCircuit
+	GPIO_WriteBit(OUT_PORT, WAKEUP_PIN, Bit_SET);
+#else
 	GPIO_WriteBit(OUT_PORT, WAKEUP_PIN, Bit_RESET);
+#endif /* SimpleCircuit */
 #endif /* ST_Link */
 	GPIO_InitStructure.GPIO_Pin = LED_PIN;
 	GPIO_InitStructure.GPIO_Mode = GPIO_Mode_Out_PP;
 	GPIO_InitStructure.GPIO_Speed = GPIO_Speed_2MHz;
 	GPIO_Init(OUT_PORT, &GPIO_InitStructure);
 	GPIO_InitStructure.GPIO_Pin = WAKEUP_PIN;
+#ifdef SimpleCircuit
+	GPIO_InitStructure.GPIO_Mode = GPIO_Mode_Out_OD;
+#endif /* SimpleCircuit */
 	GPIO_Init(OUT_PORT, &GPIO_InitStructure);
 	GPIO_InitStructure.GPIO_Pin = WAKEUP_RESET_PIN;
 	GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IPU;
+
 	GPIO_Init(RESET_PORT, &GPIO_InitStructure);
 	/* start with LED on */
 	GPIO_WriteBit(OUT_PORT, LED_PIN, Bit_SET);
@@ -260,9 +268,17 @@ void Wakeup(void)
 	/* USB wakeup */
 	Resume(RESUME_START);
 	/* motherboard switch: WAKEUP_PIN short high */
-	GPIO_WriteBit(OUT_PORT, WAKEUP_PIN, Bit_SET);
-	delay_ms(500);
+#ifdef SimpleCircuit
 	GPIO_WriteBit(OUT_PORT, WAKEUP_PIN, Bit_RESET);
+#else
+	GPIO_WriteBit(OUT_PORT, WAKEUP_PIN, Bit_SET);
+#endif /* SimpleCircuit */
+	delay_ms(500);
+#ifdef SimpleCircuit
+	GPIO_WriteBit(OUT_PORT, WAKEUP_PIN, Bit_SET);
+#else
+	GPIO_WriteBit(OUT_PORT, WAKEUP_PIN, Bit_RESET);
+#endif /* SimpleCircuit */
 	fast_toggle();
 }
 


### PR DESCRIPTION
In "SimpleCircuit" mode the firmware is built in a way that the small ST-Link boards can drive the power button active line directly without adding an opto coupler.

To make it easier to configure the firmware, I've added an optional "Make.config" support.
