### PR TITLE
Fix to only do wakeup if PC is already powered down/in standby

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -22,5 +22,5 @@ Manuel Reimer <manuel.reimer@gmx.de>
  for making the maple bootloader compile with gcc 4.9 and -Os
  for making the IRMP_STM32 firmware compatible with gcc 4.9 and -Os
  for implementing SimpleCircuit mode to drive powerbutton directly
- for implementing OnlyPowerUp mode to only operate powerbutton if powered down
+ for fixing wakeup to only operate when wakeup is needed
  for Make.config.template/Make.config support

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -21,3 +21,6 @@ Michael Kipp <myscha@web.de>
 Manuel Reimer <manuel.reimer@gmx.de>
  for making the maple bootloader compile with gcc 4.9 and -Os
  for making the IRMP_STM32 firmware compatible with gcc 4.9 and -Os
+ for implementing SimpleCircuit mode to drive powerbutton directly
+ for implementing OnlyPowerUp mode to only operate powerbutton if powered down
+ for Make.config.template/Make.config support

--- a/STM32F103/Make.config.template
+++ b/STM32F103/Make.config.template
@@ -15,9 +15,15 @@
 ### bootloader installed.
 #Bootloader=1
 
+### Enable this to only use the learned wakeup code to *start* the computer via
+### power button. If this is enabled, then the learned wakeup code is just
+### handled the same way as any other code on your remote, and does not operate
+### the power button, as soon as USB activity is detected (PC is booted up).
+#OnlyPowerUp=1
+
 ### If you enable the following option, your firmware will be able to drive the
 ### "active" pin of the mainboard power button directly. It is recommended
-### to add a 220 ohms resistor between the wakeup pin and the active pin of the 
+### to add a 220 ohms resistor between the wakeup pin and the active pin of the
 ### mainboard connector.
 ### Please be careful and check it out, if this works for your motherboard, too.
 ### Warning: This might possibly damage your motherboard or the IRMP_STM32 device!

--- a/STM32F103/Make.config.template
+++ b/STM32F103/Make.config.template
@@ -15,12 +15,6 @@
 ### bootloader installed.
 #Bootloader=1
 
-### Enable this to only use the learned wakeup code to *start* the computer via
-### power button. If this is enabled, then the learned wakeup code is just
-### handled the same way as any other code on your remote, and does not operate
-### the power button, as soon as USB activity is detected (PC is booted up).
-#OnlyPowerUp=1
-
 ### If you enable the following option, your firmware will be able to drive the
 ### "active" pin of the mainboard power button directly. It is recommended
 ### to add a 220 ohms resistor between the wakeup pin and the active pin of the

--- a/STM32F103/Makefile
+++ b/STM32F103/Makefile
@@ -17,7 +17,7 @@ OBJCP = $(CROSS_COMPILE)objcopy
 ARCH = -mcpu=cortex-m3 -mthumb
 COMMON = -g -Os -flto
 INCLUDES = -Icmsis -Icmsis_boot -Istm_lib/inc -Iusb_hid/inc -Iirmp -Isrc
-DEFINES = -D$(PLATFORM) -DSTM32F10X_MD -DUSE_STDPERIPH_DRIVER
+DEFINES = -D$(PLATFORM) -DSTM32F10X_MD -DUSE_STDPERIPH_DRIVER -DSOF_CALLBACK
 
 OBJS = src/irmpmain.o src/st_link_leds.o src/usb_hid.o src/main.o\
        irmp/irmp.o irmp/irsnd.o\
@@ -44,10 +44,6 @@ endif
 
 ifdef SimpleCircuit
 DEFINES += -DSimpleCircuit
-endif
-
-ifdef OnlyPowerUp
-DEFINES += -DOnlyPowerUp -DSOF_CALLBACK
 endif
 
 ifeq ($(Platform), Blue)

--- a/STM32F103/Makefile
+++ b/STM32F103/Makefile
@@ -46,6 +46,10 @@ ifdef SimpleCircuit
 DEFINES += -DSimpleCircuit
 endif
 
+ifdef OnlyPowerUp
+DEFINES += -DOnlyPowerUp -DSOF_CALLBACK
+endif
+
 ifeq ($(Platform), Blue)
 DEFINES += -DBlueLink
 endif

--- a/STM32F103/src/main.c
+++ b/STM32F103/src/main.c
@@ -163,9 +163,7 @@ volatile unsigned int systicks = 0;
 extern uint8_t PA9_state;
 volatile unsigned int systicks2 = 0;
 #endif /* ST_Link */
-#ifdef OnlyPowerUp
 volatile unsigned int sof_timeout = 0;
-#endif /* OnlyPowerUp */
 
 void delay_ms(unsigned int msec)
 {
@@ -256,11 +254,11 @@ void SysTick_Handler(void)
 #ifdef ST_Link
 	systicks2++;
 #endif /* ST_Link */
-#ifdef OnlyPowerUp
+
 	/* Only count up to 100 */
 	if (sof_timeout != 100)
 		sof_timeout++;
-#endif /* OnlyPowerUp */
+
 	if (i == 1000) {
 		if (AlarmValue)
 			AlarmValue--;
@@ -270,11 +268,10 @@ void SysTick_Handler(void)
 	}
 }
 
-#ifdef OnlyPowerUp
 void SOF_Callback(void) {
+	/* Reset the counter with every "StartOfFrame" event */
 	sof_timeout = 0;
 }
-#endif /* OnlyPowerUp */
 
 void Wakeup(void)
 {
@@ -429,11 +426,9 @@ int8_t reset_handler(uint8_t *buf)
 /* is received ir-code in one of the wakeup-slots? wakeup if true */
 void check_wakeups(IRMP_DATA *ir)
 {
-#ifdef OnlyPowerUp
 	/* There is bus activity -> No Wakeup */
 	if (sof_timeout != 100)
 		return;
-#endif /* OnlyPowerUp */
 
 	uint8_t i, idx;
 	uint8_t buf[SIZEOF_IR];

--- a/STM32F103/src/main.c
+++ b/STM32F103/src/main.c
@@ -257,7 +257,8 @@ void SysTick_Handler(void)
 	systicks2++;
 #endif /* ST_Link */
 #ifdef OnlyPowerUp
-	if (sof_timeout != 100) // Only count up to 100
+	/* Only count up to 100 */
+	if (sof_timeout != 100)
 		sof_timeout++;
 #endif /* OnlyPowerUp */
 	if (i == 1000) {
@@ -429,7 +430,8 @@ int8_t reset_handler(uint8_t *buf)
 void check_wakeups(IRMP_DATA *ir)
 {
 #ifdef OnlyPowerUp
-	if (sof_timeout != 100) // There is bus activity -> No Wakeup
+	/* There is bus activity -> No Wakeup */
+	if (sof_timeout != 100)
 		return;
 #endif /* OnlyPowerUp */
 


### PR DESCRIPTION
The following change disables the wakeup code as long as there is bus-activity on USB.
